### PR TITLE
docs: clarify hunting mode message

### DIFF
--- a/guides/hunting.md
+++ b/guides/hunting.md
@@ -47,7 +47,7 @@ At the top you will see a section that contains counters for the things we can h
 - `CS` - Compute Shader
 
 The numbers after them display `current`/`total count`, that is, the index of the current buffer/shader out of the total number for the scene.
-The bottom of the screen should always display "Stereo disabled".
+The bottom of the screen should display either "Shader Hunting Mode" or "Stereo disabled", depending on your version of `d3d11.dll`.
 
 The next section you will see comes up only after you have moved forward or backward through one of the above options. It displays the hash that is currently selected for each buffer or shader which can be "marked". If the setting "Dump Shaders" is enabled then it will also save the decompiled/disassembled shader to the `ShaderFixes` folder; "marking" a hash by default only copies the hash value to your system clipboard.
 


### PR DESCRIPTION
Really minor nit, but I remember this confused me a few months ago, and downgrading today reminded me about it. Looks like a [few](<https://discord.com/channels/971945032552697897/995556765179596890/1486828432422731776>) [people](<https://discord.com/channels/971945032552697897/995556765179596890/1486797953778843718>) [in](<https://discord.com/channels/971945032552697897/995556765179596890/1470644217817862298>) [the](<https://discord.com/channels/971945032552697897/995556765179596890/1437795748359049257>) [Discord](<https://discord.com/channels/971945032552697897/995556765179596890/1437345692933689405>) [got](<https://discord.com/channels/971945032552697897/995556765179596890/1434632042947149926>) [confused](<https://discord.com/channels/971945032552697897/995556765179596890/1426787026937843823>) [by](<https://discord.com/channels/971945032552697897/995556765179596890/1409950283219337266>) [this](<https://discord.com/channels/971945032552697897/998629476546134146/1399648617601695785>) [one](<https://discord.com/channels/971945032552697897/995556765179596890/1397809908585595014>), [too](<https://discord.com/channels/971945032552697897/995556765179596890/1395034114507149402>). Might also be good to just remove the line entirely?

Not sure if there are any other guides that tell people to look out for a "Stereo disabled" message, but this was the first one that I followed.